### PR TITLE
awcy: graph encode time

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -75,6 +75,7 @@
         <option value="8">Frame-averaged PSNR (Cb)</option>
         <option value="9">Frame-averaged PSNR (Cr)</option>
         <option value="10" selected>MS-SSIM</option>
+        <option value="11">Encode time</option>
       </select>
       Video:
       <select id="video_name" onChange="run_selection_changed()" style="max-width: 300px">

--- a/www/rdgraph.js
+++ b/www/rdgraph.js
@@ -47,7 +47,7 @@ function rdgraph_draw(selected_graphs, outfile, set) {
         axisLabel: 'Bits per Pixel',
       },
       yaxis: {
-        axisLabel: 'Picture quality (dB)'
+        axisLabel: metric_index == 11 ? 'Encode time (seconds)' : 'Picture quality (dB)'
       },
       legend: {
         show: true,


### PR DESCRIPTION
We may want to flip the y-axis so that up and to the left is better (as with the other graphs), however it may be jarring to see the function go down from left to right.