### PR TITLE
Add Copy to Clipboard support.

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -26,6 +26,7 @@
     "webpack-notifier": "^1.4.1"
   },
   "dependencies": {
+    "copy-to-clipboard": "^3.0.5",
     "d3-scale": "^1.0.3",
     "es6-promise": "^3.2.1",
     "flux": "^2.1.1",

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -6,6 +6,7 @@ import { BDRateReport, Report, AppStore, Jobs, Job, JobStatus, loadXHR, ReportFi
 declare var require: any;
 
 let Select = require('react-select');
+let copyToClipboard = require('copy-to-clipboard');
 
 function formatNumber(n) {
   return n.toLocaleString(); // .replace(/\.00$/, '');
@@ -135,6 +136,67 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
     this.setState({reversed: !this.state.reversed} as any);
     this.loadReport({a: report.b, b: report.a});
   }
+  onCopyToClipboardClick() {
+    function padTable(rows: any [][]) {
+      let numCols = rows[0].length;
+      let maxColWidths = new Uint32Array(numCols);
+      for (let i = 0; i < numCols; i++) {
+        for (let j = 0; j < rows.length; j++) {
+          maxColWidths[i] = Math.max(maxColWidths[i], rows[j][i].length);
+        }
+      }
+      function padLeft(s, l, c) {
+        while (s.length < l)
+            s = c + s;
+        return s;
+      }
+      function padRight(s, l, c) {
+        while (s.length < l)
+            s = s + c;
+        return s;
+      }
+      for (let i = 0; i < numCols; i++) {
+        for (let j = 0; j < rows.length; j++) {
+          rows[j][i] = padLeft(rows[j][i], maxColWidths[i], ' ');
+        }
+      }
+    }
+
+    let a = this.props.a;
+    let b = this.props.b;
+    let report = this.state.report;
+    let summaryHeaders = ["PSNR", "PSNR Cb", "PSNR Cr", "PSNR HVS", "SSIM", "MS SSIM", "CIEDE 2000"];
+    let summaryRows = [summaryHeaders];
+    summaryRows.push(summaryHeaders.map(name => report.average[name].toFixed(2)));
+    padTable(summaryRows);
+
+    let text = report.a.id + " -> " + report.b.id + "\n\n";
+    text += summaryRows.map(row => row.join(" | ")).join("\n");
+
+    function toRow(video: string, data) {
+      return [video].concat(report.metricNames.map(name => data[name].toFixed(2)));
+    }
+    let rowHeaders = ["Video"].concat(report.metricNames);
+    let rows = [rowHeaders];
+    for (let video in report.metrics) {
+      rows.push(toRow(video, report.metrics[video]));
+    }
+    padTable(rows);
+    text += "\n\n";
+    text += rows.map(row => row.join(" | ")).join("\n");
+
+    // Markdown
+    text += "\n\nMarkdown Version\n\n";
+    summaryRows.splice(1, 0, summaryHeaders.map(() => "---"));
+    padTable(summaryRows);
+    text += summaryRows.map(row => `| ${row.join(" | ")} |`).join("\n");
+
+    text += "\n\n";
+    rows.splice(1, 0, rowHeaders.map(() => "---"));
+    padTable(rows);
+    text += rows.map(row => `| ${row.join(" | ")} |`).join("\n");
+    copyToClipboard(text);
+  }
   render() {
     // console.debug("Rendering BDRateReport");
     let a = this.props.a;
@@ -168,7 +230,8 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
     }
     return <Panel header={`BD Rate Report ${report.a.selectedName + " " + report.a.id} → ${report.b.selectedName + " " + report.b.id}`}>
       <div style={{ paddingBottom: 8, paddingTop: 4 }}>
-        <Button active={this.state.reversed} onClick={this.onReverseClick.bind(this)} >Reverse</Button>
+        <Button active={this.state.reversed} onClick={this.onReverseClick.bind(this)} >Reverse</Button>{' '}
+        <Button active={this.state.reversed} onClick={this.onCopyToClipboardClick.bind(this)} >Copy to Clipboard</Button>
       </div>
       <Table striped bordered condensed hover style={{width: "100%"}}>
         <thead>

--- a/www/src/components/Report.tsx
+++ b/www/src/components/Report.tsx
@@ -187,12 +187,12 @@ export class BDRateReportComponent extends React.Component<BDRateReportProps, {
 
     // Markdown
     text += "\n\nMarkdown Version\n\n";
-    summaryRows.splice(1, 0, summaryHeaders.map(() => "---"));
+    summaryRows.splice(1, 0, summaryHeaders.map(() => "---:"));
     padTable(summaryRows);
     text += summaryRows.map(row => `| ${row.join(" | ")} |`).join("\n");
 
     text += "\n\n";
-    rows.splice(1, 0, rowHeaders.map(() => "---"));
+    rows.splice(1, 0, rowHeaders.map(() => "---:"));
     padTable(rows);
     text += rows.map(row => `| ${row.join(" | ")} |`).join("\n");
     copyToClipboard(text);


### PR DESCRIPTION
This adds the ability to copy copy-and-paste friendly BD reports to the clipboard, such as:

| PSNR | PSNR Cb | PSNR Cr | PSNR HVS | SSIM | MS SSIM | CIEDE 2000 |
| ---: |    ---: |    ---: |     ---: | ---: |    ---: |       ---: |
| 0.04 |   -1.12 |   -1.09 |     0.26 | 0.09 |    0.32 |      -0.33 |

|                                                        Video |  PSNR | PSNR HVS |  SSIM | MS SSIM | CIEDE 2000 | PSNR Cb | PSNR Cr | APSNR | APSNR Cb | APSNR Cr |
|                                                         ---: |  ---: |     ---: |  ---: |    ---: |       ---: |    ---: |    ---: |  ---: |     ---: |     ---: |
|             Netflix_Aerial_1920x1080_60fps_10bit_420_60f.y4m | -1.73 |    -1.99 | -1.44 |   -1.41 |      -1.29 |   -0.80 |   -0.08 | -1.68 |    -0.78 |    -0.12 |
|               Netflix_Boat_1920x1080_60fps_10bit_420_60f.y4m | -0.71 |    -0.16 | -0.34 |   -0.38 |      -0.92 |   -1.71 |   -1.26 | -0.70 |    -1.66 |    -1.24 |
|          Netflix_Crosswalk_1920x1080_60fps_10bit_420_60f.y4m |  1.51 |     1.80 |  1.69 |    2.00 |       1.29 |    0.21 |    0.19 |  1.54 |     0.23 |     0.22 |
|         Netflix_FoodMarket_1920x1080_60fps_10bit_420_60f.y4m |  0.75 |     0.78 | -0.20 |    0.91 |       0.12 |   -0.85 |   -1.81 |  0.71 |    -0.82 |    -1.73 |
|        Netflix_PierSeaside_1920x1080_60fps_10bit_420_60f.y4m |  0.45 |     0.70 |  0.43 |    0.49 |      -0.13 |   -0.79 |   -0.17 |  0.42 |    -0.75 |    -0.17 |
| Netflix_SquareAndTimelapse_1920x1080_60fps_10bit_420_60f.y4m | -0.37 |    -0.14 | -0.13 |   -0.00 |      -0.98 |   -1.99 |   -1.96 | -0.36 |    -1.93 |    -1.92 |
|         Netflix_TunnelFlag_1920x1080_60fps_10bit_420_60f.y4m |  0.36 |     0.82 |  0.61 |    0.66 |      -0.42 |   -1.87 |   -2.52 |  0.36 |    -1.78 |    -2.42 |