### PR TITLE
create_test_branch.sh: mkdir if it doesn't already exist

### DIFF
--- a/create_test_branch.sh
+++ b/create_test_branch.sh
@@ -11,7 +11,7 @@ TESTNAME="$2"
 CODEC="$3"
 BRANCH=t-$(echo "${TESTNAME}" | sed "s/:/_/g")
 
-cd ${CODECS_SRC_DIR}/${CODEC}
+mkdir -p ${CODECS_SRC_DIR}/${CODEC} && cd ${CODECS_SRC_DIR}/${CODEC}
 git reset --hard
 if git checkout ${COMMIT}; then
     echo "Commit found, skipping fetch."


### PR DESCRIPTION
Saw the following line in the logs when running an SVT-AV1 job. I guess this directory hasn't been created on any/all of the AWCY servers yet. This should fix it.

`./create_test_branch.sh: line 14: cd: /home/awcybeta/awcy/svt-av1: No such file or directory`

https://beta.arewecompressedyet.com/?job=%402019-02-21T21%3A35%3A04.826Z